### PR TITLE
remove erroneous text

### DIFF
--- a/modules/ROOT/pages/troubleshoot-saml-assertions-task.adoc
+++ b/modules/ROOT/pages/troubleshoot-saml-assertions-task.adoc
@@ -8,32 +8,14 @@ To view your SAML response in a browser, perform a single sign-on and use the de
 [NOTE]
 Complete this task before calling the MuleSoft Support team to assist you in troubleshooting your SAML 2.0 compliant SSO setup. 
 
-. Open a new tab in your browser and use Chrome Developer Tools, Firebug for Firefox, or a SAML tracer to be prepared to capture the SAML response. Ensure that you are preserving logs.
-
-. Go to anypoint.mulesoft.com/accounts/login/<domainname>.
-This will redirect you to your IDP's Single sign on page.
-Note: You can view your Anypoint organization's domain name by clicking Access Management -> Organizations -> <Master org>
-
-. Enter IDP account credentials and authenticate yourself.
-
-. Open a new tab in your browser and use Chrome Developer Tools, Firebug for Firefox, or a SAML tracer to be prepared to capture the SAML response. Ensure that you are preserving logs.
-
-. Select Access Management -> Organizations -> <Master org> to determine your organizations's domain name.
-
-. Go to the following URL, replacing `domain_name` with your organization's domain name:
-+
-----
-anypoint.mulesoft.com/accounts/login/<domain_name>
-----
-+
-
-. Click on the specific row that contains the URL mentioned above.
-
-. In the Form data window on the right select the Params tab.
-
+. Open a new tab in your browser and open Chrome Developer Tools, Firebug for Firefox, or a SAML tracer to capture the SAML response.
+. From Anypoint Platform, click *Access Management* -> *Organizations* -> _yourMasterOrg_, and copy the domain name.
+. Go to `anypoint.mulesoft.com/accounts/login/_domain_name_`. This will redirect you to your IDP’s Single sign on page. 
+. Enter the IDP account credentials and authenticate yourself.
+. In the Chrome developer tool *Form data* window, select the *Params* tab. Other tools or tracers may have different labels.
 . Record the SAML response element.
 
-After recording the SAML response element, you can use it to obtain a bearer token to access platform APIs. It is also useful to provide the SAML response for troubleshooting when contacting MuleSoft support.
+After recording the SAML response element, use it to obtain a bearer token to access platform APIs. It is also useful to provide the SAML response for troubleshooting when contacting MuleSoft support.
 
 . Log in to the MuleSoft Support Portal at the following URL:
 +

--- a/modules/ROOT/pages/troubleshoot-saml-assertions-task.adoc
+++ b/modules/ROOT/pages/troubleshoot-saml-assertions-task.adoc
@@ -1,9 +1,12 @@
-= To view a SAML response in your Browser
+= View a SAML Response in the Browser
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Follow this procedure to help the MuleSoft Support team to assist you in troubleshooting your SAML 2.0 compliant SSO setup or to just view your SAML response.
+To view your SAML response in a browser, perform a single sign-on and use the developer tools in your browser to find the bearer token and SAML response.
+
+[NOTE]
+Complete this task before calling the MuleSoft Support team to assist you in troubleshooting your SAML 2.0 compliant SSO setup. 
 
 . Open a new tab in your browser and use Chrome Developer Tools, Firebug for Firefox, or a SAML tracer to be prepared to capture the SAML response. Ensure that you are preserving logs.
 
@@ -23,14 +26,6 @@ Note: You can view your Anypoint organization's domain name by clicking Access M
 anypoint.mulesoft.com/accounts/login/<domain_name>
 ----
 +
-
-Click on the specific row that has the above mentioned URL. In the Form data window on the right select the Params tab and copy the SAML response element.
-
-. Log in to the MuleSoft Support Portal at the following URL:
-+
-----
-https://anypoint.mulesoft.com/accounts/login/receive-id
-----
 
 . Click on the specific row that contains the URL mentioned above.
 


### PR DESCRIPTION
- Fixed title to be init cap and remove "your" for ease of reading
- Removed the incorrect, overlapping text.
- Made the parenthetical a note, and clarified for shortdesc what you have to do (If the customer already knows how to do this, they don't have to read the instructions).