### PR TITLE
EU control plan authentication endpoint is different

### DIFF
--- a/modules/ROOT/pages/managing-users.adoc
+++ b/modules/ROOT/pages/managing-users.adoc
@@ -16,7 +16,9 @@ Configuring SAML for SSO involves:
 * Your Anypoint Platform organization must be set up as your audience.
 * The assertion consumer service must be set to send a `POST` request to `+https://anypoint.mulesoft.com/accounts/login/receive-id+`.
 
-Note, for Anypoint Platform EU Control Plane, the endpoint is `+https://eu1.anypoint.mulesoft.com/accounts/login/receive-id+`.
+[NOTE]
+If you are using the Anypoint Platform EU Control Plane, the endpoint is `+https://eu1.anypoint.mulesoft.com/accounts/login/receive-id+`.
+If you are using the Anypoint Platform Gov Cloud, the endpoint is  `+https://gov.anypoint.mulesoft.com/accounts/login/receive-id+`
 
 == Configure SAML in Identity Management
 

--- a/modules/ROOT/pages/managing-users.adoc
+++ b/modules/ROOT/pages/managing-users.adoc
@@ -16,6 +16,8 @@ Configuring SAML for SSO involves:
 * Your Anypoint Platform organization must be set up as your audience.
 * The assertion consumer service must be set to send a `POST` request to `+https://anypoint.mulesoft.com/accounts/login/receive-id+`.
 
+Note, for Anypoint Platform EU Control Plane, the endpoint is `+https://eu1.anypoint.mulesoft.com/accounts/login/receive-id+`.
+
 == Configure SAML in Identity Management
 
 . In Anypoint Platform, sign into the master organization as a user with the *Organization Administrators*.

--- a/modules/ROOT/pages/managing-users.adoc
+++ b/modules/ROOT/pages/managing-users.adoc
@@ -17,8 +17,10 @@ Configuring SAML for SSO involves:
 * The assertion consumer service must be set to send a `POST` request to `+https://anypoint.mulesoft.com/accounts/login/receive-id+`.
 
 [NOTE]
-If you are using the Anypoint Platform EU Control Plane, the endpoint is `+https://eu1.anypoint.mulesoft.com/accounts/login/receive-id+`.
-If you are using the Anypoint Platform Gov Cloud, the endpoint is  `+https://gov.anypoint.mulesoft.com/accounts/login/receive-id+`
+====
+* If you are using the Anypoint Platform EU Control Plane, the endpoint is `+https://eu1.anypoint.mulesoft.com/accounts/login/receive-id+`. +
+* If you are using the Anypoint Platform Gov Cloud, the endpoint is  `+https://gov.anypoint.mulesoft.com/accounts/login/receive-id+`
+====
 
 == Configure SAML in Identity Management
 


### PR DESCRIPTION
EU control plan authentication endpoint is https://eu1.anypoint.mulesoft.com/accounts/login/receive-id instead of https://anypoint.mulesoft.com/accounts/login/receive-id. Need a caveat on this.