### PR TITLE
Update managing-users Username attribute

### DIFF
--- a/modules/ROOT/pages/managing-users.adoc
+++ b/modules/ROOT/pages/managing-users.adoc
@@ -54,7 +54,7 @@ An arbitrary string value that identifies your Anypoint Platform organization. T
 +
 * *Username Attribute*
 +
-Field name in the SAML `AttributeStatements` that maps to username. By default, the `NameID` attribute of the SAML `Subject` in the SAML assertion is used.
+Field name in the SAML `AttributeStatements` that maps to username. If no value is configured, the `NameID` attribute of the SAML `Subject` is used (Note: this is outside the SAML `AttributeStatements`).
 +
 * *First Name Attribute*
 +


### PR DESCRIPTION
Updates the description for where the Username attribute to clarify that the locations in the SAML assertion are different between the default (empty) value and if a value is configured. This hopefully will avoid future confusion.