### PR TITLE
Removing the limitation of deleting clients

### DIFF
--- a/modules/ROOT/pages/configure-client-management-openid-task.adoc
+++ b/modules/ROOT/pages/configure-client-management-openid-task.adoc
@@ -7,13 +7,6 @@ endif::[]
 
 MuleSoft supports client management by identity providers that implement the OpenID Connect Dynamic Client Registration open standard.  MuleSoft explicitly verifies support in Anypoint Platform for Salesforce, Okta, and OpenAM v14 Dynamic Client Registration.
 
-[NOTE]
-====
-* Updates of clients created through this integration are not currently supported.
-* Deletion of clients created through this integration is supported with the limitation that the client is removed from Anypoint Platform but still exists in the OpenID Connect authorization server and API policies still consider them valid until the cached token expires.
-* To enable this functionality you must opt-in by selecting the checkbox *Enable client deletion in Anypoint* under the *Advanced* settings link.
-====
-
 The following table contains examples of the URLs you need to supply, depending on your provider, during registration.
 
 [%autowidth.spread]


### PR DESCRIPTION
Removed the following

"
[NOTE]
====
* Updates of clients created through this integration are not currently supported.
* Deletion of clients created through this integration is supported with the limitation that the client is removed from Anypoint Platform but still exists in the OpenID Connect authorization server and API policies still consider them valid until the cached token expires.
* To enable this functionality you must opt-in by selecting the checkbox *Enable client deletion in Anypoint* under the *Advanced* settings link.
====
"

As it's already supported and conflicts with the following in the same page:

"
  *** *Enable client deletion in Anypoint Platform*: Enables deletion of clients created with this integration.
  *** *Enable client deletion and updates in IdP*: To use this option, you must also select the *Enable client deletion in Anypoint Platform* option. This option enables you to update and delete external clients in the configured IdP through an outbound call made by Anypoint Platform to `{clientRegistrationUrl}/{clientID}`. The `clientRegistrationUrl` is the value you configured in *Client Registration URL*. For example: 
"