### PR TITLE
Update sso-prerequisites-about.adoc

### DIFF
--- a/modules/ROOT/pages/sso-prerequisites-about.adoc
+++ b/modules/ROOT/pages/sso-prerequisites-about.adoc
@@ -37,7 +37,6 @@ https://anypoint.mulesoft.com/accounts/login/{your_org_domain}
 == Limitations
 
 * OpenID Connect does not support single logout.
-* OpenID Connect does not support role mapping.
 * If a SAML user belongs to certain groups, Anypoint Platform does not automatically grant equivalent roles in the organization.
 * Anypoint Platform does not generate the SAML assertion for single sign on.
 Your IdP generates the sign-on URL that you configure.


### PR DESCRIPTION
According to the Dec 15 2020 update to Access Management, OpenID Connect now supports mapping roles:
https://docs.mulesoft.com/release-notes/access-management/access-management-release-notes#december-15-2020