### PR TITLE
Update audit-logging.adoc

### DIFF
--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1179,14 +1179,6 @@ Properties:
 * Target
 * Role
 
-|Request an asset file
-|Asset file
-|Asset ID and classifier
-|N/A
-|Download
-|Subaction: None +
-Properties: file metadata
-
 |Update an asset icon
 |Asset icon
 |Asset ID

--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1195,7 +1195,7 @@ Properties: Asset object
 |Subaction: None +
 Properties: Asset object
 
-|Create a managed tag
+|Create a managed tag (Category)
 |Asset managed tag
 |Asset ID and tag ID
 |Asset
@@ -1203,7 +1203,7 @@ Properties: Asset object
 |Subaction: None +
 Properties: None
 
-|Delete a managed tag
+|Delete a managed tag (Category)
 |Asset managed tag
 |Asset ID and tag ID
 |Asset

--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1195,6 +1195,22 @@ Properties: Asset object
 |Subaction: None +
 Properties: Asset object
 
+|Create a managed tag
+|Asset managed tag
+|Asset ID and tag ID
+|Asset
+|Create
+|Subaction: None +
+Properties: None
+
+|Delete a managed tag
+|Asset managed tag
+|Asset ID and tag ID
+|Asset
+|Delete
+|Subaction: None +
+Properties: None
+
 |Delete an organization
 |Organization
 |Organization ID

--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1195,7 +1195,7 @@ Properties: Asset object
 |Subaction: None +
 Properties: Asset object
 
-|Create a managed tag (Category)
+|Create a managed tag (category)
 |Asset managed tag
 |Asset ID and tag ID
 |Asset
@@ -1203,7 +1203,7 @@ Properties: Asset object
 |Subaction: None +
 Properties: None
 
-|Delete a managed tag (Category)
+|Delete a managed tag (category)
 |Asset managed tag
 |Asset ID and tag ID
 |Asset

--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1195,22 +1195,6 @@ Properties: Asset object
 |Subaction: None +
 Properties: Asset object
 
-|Create a managed tag
-|Asset managed tag
-|Asset ID and tag ID
-|Asset
-|Create
-|Subaction: None +
-Properties: None
-
-|Delete a managed tag
-|Asset managed tag
-|Asset ID and tag ID
-|Asset
-|Delete
-|Subaction: None +
-Properties: None
-
 |Delete an organization
 |Organization
 |Organization ID


### PR DESCRIPTION
Removing invalid audit log event in Exchange documentation. There are no audit log events of read-only operations in Exchange. We will investigate why this event reached the documentation. 