### PR TITLE
DOCS-10667: Update audit-logging to include DataGraph logs

### DIFF
--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1153,21 +1153,21 @@ Environments that are created automatically when you create an organization or b
 | User
 | data-graph-{api-name}-{env-name}
 | N/A
-| Create
+| Add API
 | N/A
 
 | Update API
 | User
 | data-graph-{api-name}-{env-name}
 | N/A
-| Update
+| Update API
 | N/A
 
 | Remove API
 | User
 | data-graph-{api-name}-{env-name}
 | N/A
-| Delete
+| Remove API
 | N/A
 
 |===

--- a/modules/ROOT/pages/audit-logging.adoc
+++ b/modules/ROOT/pages/audit-logging.adoc
@@ -1138,6 +1138,41 @@ Environments that are created automatically when you create an organization or b
 
 |===
 
+== Anypoint DataGraph
+
+[%header,cols="25a,15a,15a,15a,15a,30a"]
+|===
+|User Action
+|Object Type
+|Object
+|Parent
+|Action
+|Payload
+
+| Add API
+| User
+| data-graph-{api-name}-{env-name}
+| N/A
+| Create
+| N/A
+
+| Update API
+| User
+| data-graph-{api-name}-{env-name}
+| N/A
+| Update
+| N/A
+
+| Remove API
+| User
+| data-graph-{api-name}-{env-name}
+| N/A
+| Delete
+| N/A
+
+|===
+
+
 == Exchange
 
 === Assets

--- a/modules/ROOT/pages/users.adoc
+++ b/modules/ROOT/pages/users.adoc
@@ -42,7 +42,7 @@ Invited users have access to the same set of resources as you (although they may
 
 Click *Pending Invites* to view all invitations that have not yet been accepted. Select the ones you need to manage, and click *Re-send Invite* or *Cancel Invite*.
 
-
+[[granting-permissions-and-roles-to-users]]
 == Granting Permissions and Roles to Users
 
 Click a user name to access more information about that user, add roles and permissions to it, or reset its password.


### PR DESCRIPTION
This PR adds the following table containing Anypoint DataGraph audit logs information:

![Screen Shot 2021-04-26 at 12 17 55 PM](https://user-images.githubusercontent.com/16763154/116107681-9d9d6380-a689-11eb-9f9e-53fa4c8f81dd.png)


This content will be used in a beta site for field validation.

**DO NOT MERGE** this content into latest yet.