### PR TITLE
document the limit of scopes in one connected app

### DIFF
--- a/modules/ROOT/pages/connected-apps-developers.adoc
+++ b/modules/ROOT/pages/connected-apps-developers.adoc
@@ -74,7 +74,7 @@ For more information about how to embed the button, refer to the https://anypoin
 
 Before you create an app as an organization administrator, consider the following requirements and restrictions:
 
-* Your organization can own up to 200 connected apps.
+* Your organization can own up to 200 connected apps, and each connected app can have up to 1000 scopes.
 * A unique `clientID` is automatically assigned and can’t be modified.
 However, you can modify client secrets in the *Application Settings* page.
 * Your app is owned by your organization; any organization administrator can control it.


### PR DESCRIPTION
we need to document the limit of scopes so that customers can bear this in mind when designing the CICD/DevOps applications. instead of learning the limit after reaching it then redesign the whole thing. 