### PR TITLE
add extra explanation to Primary Key configuration

### DIFF
--- a/modules/ROOT/pages/managing-users.adoc
+++ b/modules/ROOT/pages/managing-users.adoc
@@ -47,7 +47,7 @@ ID of the identity provider instance that sends SAML assertions.
 +
 * *Public Key*
 +
-Public key provided by the identity provider, which is used to sign the SAML assertion.
+Public key provided by the identity provider, which is used to sign the SAML assertion. It is the "X509Certificate" value in the SAML Response. 
 +
 * *Audience*
 +


### PR DESCRIPTION
based on the customer feedback in case 00308504:

"
It is not clear that what is required is the object in the same format as is supplied in the SAMLResponse - in this case the object supplied was the correct public key used to sign the SAMLResponse (which is what the instructions ask for). It seems that a note in the instructions to use the certificate not the public key (if that's what's returned in the SAMLResponse), and that the two must match, would prevent future tickets of this type.
"