### PR TITLE
Update external-identity.adoc

### DIFF
--- a/modules/ROOT/pages/external-identity.adoc
+++ b/modules/ROOT/pages/external-identity.adoc
@@ -55,11 +55,6 @@ After configuring external identity management, you must add new SSO users using
 
 Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.
 
-== Multiple Identity Providers
-* Multiple IDP was released back in November 2021 
-* Organization administrators can now configure up to 25 SAML 2.0 or OpenID Connect identity providers (IdPs) for single sign-on.
-* To support multiple external IdPs, there are new endpoints available for the Access Management API; existing identity provider configurations are unaffected.
-
 == See Also
 
 * xref:conf-openid-connect-task.adoc[Configure OpenID Connect]

--- a/modules/ROOT/pages/external-identity.adoc
+++ b/modules/ROOT/pages/external-identity.adoc
@@ -49,9 +49,11 @@ The IdP you select is effective for the entire organization and all business gro
 
 For more information, see the documentation for your identity provider.
 
-== External Identity Users
-* After configuring identity management, you must add new SSO users using your external identity management solution and internal provisioning process. If you use the Invite User feature to add users to your organization after you have configured an identity provider, the credentials for these users are stored locally in your organization rather than with the identity provider.
-* Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.
+== Managing Users with an External Identity Provider
+
+After configuring external identity management, you must add new SSO users using your external identity management solution and internal provisioning process. If you use the Invite User feature to add users to your organization after you have configured an identity provider, the credentials for these users are stored locally in your organization rather than with the identity provider.
+
+Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.
 
 == Multiple Identity Providers
 * Multiple IDP was released back in November 2021 

--- a/modules/ROOT/pages/external-identity.adoc
+++ b/modules/ROOT/pages/external-identity.adoc
@@ -49,9 +49,14 @@ The IdP you select is effective for the entire organization and all business gro
 
 For more information, see the documentation for your identity provider.
 
-After configuring identity management, you must add new SSO users using your external identity management solution and internal provisioning process. If you use the Invite User feature to add users to your organization after you have configured an identity provider, the credentials for these users are stored locally in your organization rather than with the identity provider.
+== External Identity Users
+* After configuring identity management, you must add new SSO users using your external identity management solution and internal provisioning process. If you use the Invite User feature to add users to your organization after you have configured an identity provider, the credentials for these users are stored locally in your organization rather than with the identity provider.
+* Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.
 
-Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.
+== Multiple Identity Providers
+* Multiple IDP was released back in November 2021 
+* Organization administrators can now configure up to 25 SAML 2.0 or OpenID Connect identity providers (IdPs) for single sign-on.
+* To support multiple external IdPs, there are new endpoints available for the Access Management API; existing identity provider configurations are unaffected.
 
 == See Also
 

--- a/modules/ROOT/pages/external-identity.adoc
+++ b/modules/ROOT/pages/external-identity.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-As the Anypoint Platform organization administrator, you can configure identity management in Anypoint Platform to set up users for single sign-on (SSO). Configure identity management using one of the following single sign-on standards:
+As the Anypoint Platform organization administrator, you can configure identity management in Anypoint Platform to set up users for single sign-on (SSO). An organization can have up to 25 external identity providers, or _IdPs_, configured for SSO. Configure identity management using one of the following single sign-on standards:
 
 * OpenID Connect: End user identity verification by an authorization server including SSO
 +


### PR DESCRIPTION


Create a sub heading > External Identity Users  
        * Move below two items which is already exists in the docs to section
            * <Exists> After configuring identity management, you must add new SSO users using your external identity management solution and internal provisioning process. If you use the Invite User feature to add users to your organization after you have configured an identity provider, the credentials for these users are stored locally in your organization rather than with the identity provider.
            * <Exists>Users that log in with SSO are new users to the system. If the new user has the same username as a user that already exists in your Anypoint Platform organization, the new user co-exists with the original user with the same username. Users with the same username are managed independently from one another.

Create a new section “Multiple Identity Providers”
* Multiple IDP was released back in [November 2021](https://docs.mulesoft.com/release-notes/access-management/access-management-release-notes#whats-new-3) ), 
                * better to documented stuff from release pg to main IDP pg