### PR TITLE
invitation is not available to Gov Cloud

### DIFF
--- a/modules/ROOT/pages/users.adoc
+++ b/modules/ROOT/pages/users.adoc
@@ -22,7 +22,7 @@ Before getting started, ensure that you have:
 
 [NOTE]
 --
-This feature is not available in Anypoint Platform Private Cloud Edition or for organizations that use external identity providers for single sign-on (SSO). You must manage users, including invitations for new users, through your third-party IdP or LDAP.
+This feature is not available in Anypoint Platform Private Cloud Edition, Government Cloud or for organizations that use external identity providers for single sign-on (SSO). You must manage users, including invitations for new users, through your third-party IdP or LDAP.
 --
 
 As an organization administrator of a root organization or of one of its business groups, you can invite new users and manage existing users for your organization.


### PR DESCRIPTION
it's documented here: https://docs.mulesoft.com/gov-cloud/gov-cloud-account-setup:

```
Government Cloud does not support the configuration of local users, for which usernames and encrypted passwords are stored outside of Government Cloud.
```

However, it's better to be explicit in the user invitation document