### PR TITLE
Fix exchange permissions

### DIFF
--- a/modules/ROOT/pages/permissions-by-product.adoc
+++ b/modules/ROOT/pages/permissions-by-product.adoc
@@ -48,10 +48,20 @@ Or:
 
 * Design Center Developer
 * Design Center Contributor
-* Exchange
+
+== Exchange
+
+Organization level permissions:
+
 * Exchange Administrator
 * Exchange Contributor
 * Exchange Viewer
+
+Asset level permissions:
+
+* Asset Administrator
+* Asset Contributor
+* Asset Viewer
 
 == Anypoint Monitoring
 


### PR DESCRIPTION
- Fixed the markdown error that made Exchange permissions appear inside the "Design Center" section
- Added asset-level permissions
- Added differentiation between organization-level permissions and asset-level permissions 