### PR TITLE
Update configure-client-management-azure.adoc

### DIFF
--- a/modules/ROOT/pages/configure-client-management-azure.adoc
+++ b/modules/ROOT/pages/configure-client-management-azure.adoc
@@ -49,7 +49,7 @@ Anypoint Platform does not support custom scopes. Use the default scope for Micr
 
 === Grant Types === 
 
-Microsoft doesn't support specifying grant types when creating a new application and it supports "authorization_code" and "client_credentials" by default. 
+Microsoft doesn't support specifying grant types when https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http[creating a new application] and it supports "authorization_code" and "client_credentials" by default. 
 
 == See Also
 

--- a/modules/ROOT/pages/configure-client-management-azure.adoc
+++ b/modules/ROOT/pages/configure-client-management-azure.adoc
@@ -47,7 +47,7 @@ Use the following properties when you are using the Authorization Code grant typ
 
 Anypoint Platform does not support custom scopes. Use the default scope for Microsoft Graph. 
 
-=== Grant Types === 
+=== Grant Types
 
 Microsoft doesn't support specifying grant types when https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http[creating a new application] and it supports "authorization_code" and "client_credentials" by default. 
 

--- a/modules/ROOT/pages/configure-client-management-azure.adoc
+++ b/modules/ROOT/pages/configure-client-management-azure.adoc
@@ -49,7 +49,7 @@ Anypoint Platform does not support custom scopes. Use the default scope for Micr
 
 === Grant Types
 
-Microsoft doesn't support specifying grant types when https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http[creating a new application] and it supports "authorization_code" and "client_credentials" by default. 
+For a list of supported grant types, see the https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow[Microsoft identity platform documentation].
 
 == See Also
 

--- a/modules/ROOT/pages/configure-client-management-azure.adoc
+++ b/modules/ROOT/pages/configure-client-management-azure.adoc
@@ -49,6 +49,8 @@ Anypoint Platform does not support custom scopes. Use the default scope for Micr
 
 === Grant Types
 
+When https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0&tabs=http[creating a new application] with Microsoft Azure AD client provider, Anypoint Platform doesn't support grant types selection due to Microsoft Azure AD limitations.
+
 For a list of supported grant types, see the https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow[Microsoft identity platform documentation].
 
 == See Also

--- a/modules/ROOT/pages/configure-client-management-azure.adoc
+++ b/modules/ROOT/pages/configure-client-management-azure.adoc
@@ -47,7 +47,9 @@ Use the following properties when you are using the Authorization Code grant typ
 
 Anypoint Platform does not support custom scopes. Use the default scope for Microsoft Graph. 
 
+=== Grant Types === 
 
+Microsoft doesn't support specifying grant types when creating a new application and it supports "authorization_code" and "client_credentials" by default. 
 
 == See Also
 


### PR DESCRIPTION
Added clarification regarding grant types. The idea is that 
1. we don't support specify/restrict "grant types" when creating a new app
2. by default, it support 2 grant types: authorization_code and client_credentials.

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released