### PR TITLE
[W-20976280] fix help.salesforce.com links

### DIFF
--- a/modules/ROOT/pages/enabling-agentforce.adoc
+++ b/modules/ROOT/pages/enabling-agentforce.adoc
@@ -15,7 +15,7 @@ Before enabling Agentforce in your Anypoint Platform organization, you must:
  
 * Have administrative access to an Anypoint Platform organization that isn't a trial organization and isn't expired.
 * Have the root Organization Administrator permission and role.
-* Have administrative access to a Salesforce organization that https://help.salesforce.com/s/articleView?id=sf.generative_ai_enable.htm&type=5[has Agentforce enabled]. 
+* Have administrative access to a Salesforce organization that https://help.salesforce.com/s/articleView?id=ai.generative_ai_enable.htm&type=5[has Agentforce enabled]. 
 * xref:access-management::trusted-salesforce-org.adoc[Establish a tenant relationship] between your Anypoint Platform organization and a trusted Salesforce organization. 
 
 [[enable-einstein-salesforce]]

--- a/modules/ROOT/pages/managing-connected-salesforce-orgs.adoc
+++ b/modules/ROOT/pages/managing-connected-salesforce-orgs.adoc
@@ -57,7 +57,7 @@ include::partial$include-salesforce-mulesoft-setup-nav.adoc[]
 
 Alternatively, to temporarily prevent Anypoint Platform users from publishing assets to Salesforce from the Anypoint Platform side, you can <<enable-disable-connection,disable>> the connection temporarily instead.
 
-For more information about managing this relationship from the Salesforce user interface, see the https://help.salesforce.com/s/articleView?id=sf.external_services_manage_your_mulesoft_anypoint_platform_connection.htm&type=5[Salesforce documentation]. 
+For more information about managing this relationship from the Salesforce user interface, see the https://help.salesforce.com/s/articleView?id=platform.external_services_manage_your_mulesoft_anypoint_platform_connection.htm&type=5[Salesforce documentation]. 
 
 [[repairing-org-connection]]
 == Repair the Connection to a Salesforce Organization


### PR DESCRIPTION
## Summary
Applied text replacement for Salesforce documentation URL updates in docs-access-management.

## Changes
- Replaced URLs in 2 file(s)

## Files Changed
- ./modules/ROOT/pages/enabling-agentforce.adoc
- ./modules/ROOT/pages/managing-connected-salesforce-orgs.adoc

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Refactor
- [ ] Documentation

## Related
- GUS Work Item: W-20976280