### PR TITLE
Document auto-creation of CloudHub Admin roles per environment

### DIFF
--- a/modules/ROOT/pages/roles.adoc
+++ b/modules/ROOT/pages/roles.adoc
@@ -54,7 +54,7 @@ For more information on permissions in Anypoint Platform, see xref:managing-perm
 ** Manage Settings
 ** Read Applications
 +
-When you create an environment under a business group, Anypoint Platform automatically creates a `CloudHub Admin (<environment name>)` role for that environment. All users with the Organization Administrator permission on that business group are automatically added to this role. To remove users from this role, go to *Access Management* > *Business Groups* > *Roles* after creating the environment.
+When you create an environment under a business group, Anypoint Platform automatically creates a *CloudHub Admin (<environment name>)* role for that environment. All users with the Organization Administrator permission on that business group are automatically added to this role. To remove users from this role, go to *Access Management* > *Business Groups* > *Roles* after creating the environment.
 
 * **CloudHub Developer**: *(Deprecated)* Provides access to all Runtime Manager functionality, except organization and billing settings. This role has the following permission scopes:
 +

--- a/modules/ROOT/pages/roles.adoc
+++ b/modules/ROOT/pages/roles.adoc
@@ -53,6 +53,8 @@ For more information on permissions in Anypoint Platform, see xref:managing-perm
 ** Manage Servers
 ** Manage Settings
 ** Read Applications
++
+When you create an environment under a business group, Anypoint Platform automatically creates a `CloudHub Admin (<environment name>)` role for that environment. All users with the Organization Administrator permission on that business group are automatically added to this role. To remove users from this role, go to *Access Management* > *Business Groups* > *Roles* after creating the environment.
 
 * **CloudHub Developer**: *(Deprecated)* Provides access to all Runtime Manager functionality, except organization and billing settings. This role has the following permission scopes:
 +


### PR DESCRIPTION
When an environment is created under a business group, Anypoint Platform automatically creates a CloudHub Admin (<environment name>) role and assigns all Organization Administrators to it. This is intentional behavior but was undocumented, leading to customer confusion.

Adds documentation explaining this auto-creation and assignment behavior, and provides guidance on how to remove users from the role if needed.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released